### PR TITLE
concept for edible legendary fish

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -182,17 +182,17 @@ dependencies {
     compileOnly fg.deobf("com.teammetallurgy.aquaculture:aquaculture2_${minecraft_version}:${minecraft_version}-2.5.2")
 
     // nether depths
-    compileOnly fg.deobf("blank:netherdepthsupgrade-3.1.5:1.20")
+    compileOnly fg.deobf("blank:ndu:${minecraft_version}")
 
     // geckolib (for nether depths)
     //runtimeOnly fg.deobf("software.bernie.geckolib:geckolib-forge-${minecraft_version}:4.4.6")
     //runtimeOnly("com.eliotlash.mclib:mclib:20")
 
     // quality food
-    implementation fg.deobf("blank:quality_food-1.20.1:1.7.3-all")
+    implementation fg.deobf("blank:quality_food:${minecraft_version}")
 
     // tide
-    implementation fg.deobf("blank:tide-forge-1.20.1:1.6.2")
+    implementation fg.deobf("blank:tide:${minecraft_version}")
 
     // cloth config (for tide)
     runtimeOnly(fg.deobf("me.shedaniel.cloth:cloth-config-forge:11.1.136"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ mod_name=Stardew Fishing
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=MIT
 # The mod version. See https://semver.org/
-mod_version=3.0
+mod_version=3.1
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/com/bonker/stardewfishing/client/ClientEvents.java
+++ b/src/main/java/com/bonker/stardewfishing/client/ClientEvents.java
@@ -3,10 +3,10 @@ package com.bonker.stardewfishing.client;
 import com.bonker.stardewfishing.SFConfig;
 import com.bonker.stardewfishing.StardewFishing;
 import com.bonker.stardewfishing.common.init.SFBlockEntities;
+import com.bonker.stardewfishing.common.init.SFParticles;
 import com.bonker.stardewfishing.common.init.SFSoundEvents;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
-import net.minecraft.client.renderer.blockentity.BlockEntityRenderers;
 import net.minecraft.client.resources.sounds.SimpleSoundInstance;
 import net.minecraft.client.resources.sounds.SoundInstance;
 import net.minecraft.sounds.SoundEvent;
@@ -14,12 +14,12 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.ContainerScreenEvent;
 import net.minecraftforge.client.event.EntityRenderersEvent;
+import net.minecraftforge.client.event.RegisterParticleProvidersEvent;
 import net.minecraftforge.client.event.RenderTooltipEvent;
 import net.minecraftforge.client.event.sound.PlaySoundSourceEvent;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 
 public class ClientEvents {
     @Mod.EventBusSubscriber(modid = StardewFishing.MODID, value = Dist.CLIENT)
@@ -90,6 +90,11 @@ public class ClientEvents {
         @SubscribeEvent
         public static void onRegisterRenderers(final EntityRenderersEvent.RegisterRenderers event) {
             event.registerBlockEntityRenderer(SFBlockEntities.FISH_DISPLAY.get(), FishDisplayBER::new);
+        }
+
+        @SubscribeEvent
+        public static void onParticleRegistration(final RegisterParticleProvidersEvent event) {
+            event.registerSpriteSet(SFParticles.SPARKLE.get(), SparkleParticle.Provider::new);
         }
     }
 }

--- a/src/main/java/com/bonker/stardewfishing/client/FishingScreen.java
+++ b/src/main/java/com/bonker/stardewfishing/client/FishingScreen.java
@@ -205,7 +205,7 @@ public class FishingScreen extends Screen {
         }
 
         if (status != Status.HIT_TEXT) {
-            pGuiGraphics.drawString(font, StardewFishing.MOD_NAME, 2, height - 2 - font.lineHeight, 0x6969697F);
+            pGuiGraphics.drawString(font, StardewFishing.MOD_NAME, 2, height - 2 - font.lineHeight, 0x6969697F, false);
         }
     }
 

--- a/src/main/java/com/bonker/stardewfishing/common/CommonEvents.java
+++ b/src/main/java/com/bonker/stardewfishing/common/CommonEvents.java
@@ -148,11 +148,6 @@ public class CommonEvents {
         }
 
         @SubscribeEvent
-        public static void onParticleRegistration(final RegisterParticleProvidersEvent event) {
-            event.registerSpriteSet(SFParticles.SPARKLE.get(), SparkleParticle.Provider::new);
-        }
-
-        @SubscribeEvent
         public static void onAttributeCreation(final EntityAttributeModificationEvent event) {
             event.add(EntityType.PLAYER, SFAttributes.LINE_STRENGTH.get());
             event.add(EntityType.PLAYER, SFAttributes.BAR_SIZE.get());

--- a/src/main/java/com/bonker/stardewfishing/common/init/SFItems.java
+++ b/src/main/java/com/bonker/stardewfishing/common/init/SFItems.java
@@ -5,6 +5,9 @@ import com.bonker.stardewfishing.common.items.SFBobberItem;
 import com.bonker.stardewfishing.common.items.SFTooltipItem;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.food.FoodProperties;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -36,45 +39,106 @@ public class SFItems {
 
     public static final RegistryObject<Item> QUALITY_BOBBER = ITEMS.register("quality_bobber",
             () -> new SFBobberItem(new Item.Properties().durability(64)) {
-        @Override
-        protected List<Component> makeTooltip() {
-            List<Component> tooltip = super.makeTooltip();
-            if (StardewFishing.QUALITY_FOOD_INSTALLED) {
-                tooltip.add(1, Component.translatable(getDescriptionId() + ".quality_food_tooltip").withStyle(StardewFishing.LIGHTER_COLOR));
-            }
-            return tooltip;
-        }
-    });
+                @Override
+                protected List<Component> makeTooltip() {
+                    List<Component> tooltip = super.makeTooltip();
+                    if (StardewFishing.QUALITY_FOOD_INSTALLED) {
+                        tooltip.add(1, Component.translatable(getDescriptionId() + ".quality_food_tooltip").withStyle(StardewFishing.LIGHTER_COLOR));
+                    }
+                    return tooltip;
+                }
+            });
 
     public static final RegistryObject<Item> GOLIATH_GROUPER = ITEMS.register("goliath_grouper",
-            () -> new SFTooltipItem(new Item.Properties()));
+            () -> new SFTooltipItem(new Item.Properties()
+                    .food(new FoodProperties.Builder()
+                            .nutrition(30)
+                            .saturationMod(40f)
+                            .effect(() -> new MobEffectInstance(MobEffects.DAMAGE_BOOST, 6000, 2), 1.0f)
+                            .effect(() -> new MobEffectInstance(MobEffects.DAMAGE_RESISTANCE, 6000, 2), 1.0f)
+                            .build())));
 
     public static final RegistryObject<Item> VAMPIRE_PAYARA = ITEMS.register("vampire_payara",
-            () -> new SFTooltipItem(new Item.Properties()));
+            () -> new SFTooltipItem(new Item.Properties()
+                    .food(new FoodProperties.Builder()
+                            .nutrition(30)
+                            .saturationMod(40f)
+                            .effect(() -> new MobEffectInstance(MobEffects.REGENERATION, 3600, 2), 1.0f)
+                            .effect(() -> new MobEffectInstance(MobEffects.NIGHT_VISION, 12000, 0), 1.0f)
+                            .build())));
 
     public static final RegistryObject<Item> GOLDEN_SNOOK = ITEMS.register("golden_snook",
-            () -> new SFTooltipItem(new Item.Properties()));
+            () -> new SFTooltipItem(new Item.Properties()
+                    .food(new FoodProperties.Builder()
+                            .nutrition(30)
+                            .saturationMod(40f)
+                            .effect(() -> new MobEffectInstance(MobEffects.ABSORPTION, 12000, 4), 1.0f)
+                            .effect(() -> new MobEffectInstance(MobEffects.LUCK, 12000, 1), 1.0f)
+                            .effect(() -> new MobEffectInstance(MobEffects.GLOWING, 12000, 0), 1.0f)
+                            .build())));
 
     public static final RegistryObject<Item> SABRETOOTHED_TIGERFISH = ITEMS.register("sabretoothed_tigerfish",
-            () -> new SFTooltipItem(new Item.Properties()));
+            () -> new SFTooltipItem(new Item.Properties()
+                    .food(new FoodProperties.Builder()
+                            .nutrition(30)
+                            .saturationMod(40f)
+                            .effect(() -> new MobEffectInstance(MobEffects.DAMAGE_BOOST, 6000, 3), 1.0f)
+                            .effect(() -> new MobEffectInstance(MobEffects.MOVEMENT_SPEED, 6000, 3), 1.0f)
+                            .build())));
 
     public static final RegistryObject<Item> CHROMATIC_ARAPAIMA = ITEMS.register("chromatic_arapaima",
-            () -> new SFTooltipItem(new Item.Properties()));
+            () -> new SFTooltipItem(new Item.Properties()
+                    .food(new FoodProperties.Builder()
+                            .nutrition(30)
+                            .saturationMod(40f)
+                            .effect(() -> new MobEffectInstance(MobEffects.FIRE_RESISTANCE, 12000, 0), 1.0f)
+                            .effect(() -> new MobEffectInstance(MobEffects.WATER_BREATHING, 12000, 0), 1.0f)
+                            .build())));
 
     public static final RegistryObject<Item> CYCLOPS_MAHIMAHI = ITEMS.register("cyclops_mahimahi",
-            () -> new SFTooltipItem(new Item.Properties()));
+            () -> new SFTooltipItem(new Item.Properties()
+                    .food(new FoodProperties.Builder()
+                            .nutrition(30)
+                            .saturationMod(40f)
+                            .effect(() -> new MobEffectInstance(MobEffects.DAMAGE_BOOST, 3600, 2), 1.0f)
+                            .effect(() -> new MobEffectInstance(MobEffects.JUMP, 3600, 2), 1.0f)
+                            .build())));
 
     public static final RegistryObject<Item> STORM_TARPON = ITEMS.register("storm_tarpon",
-            () -> new SFTooltipItem(new Item.Properties()));
+            () -> new SFTooltipItem(new Item.Properties()
+                    .food(new FoodProperties.Builder()
+                            .nutrition(30)
+                            .saturationMod(40f)
+                            .effect(() -> new MobEffectInstance(MobEffects.DOLPHINS_GRACE, 8000, 0), 1.0f)
+                            .effect(() -> new MobEffectInstance(MobEffects.CONDUIT_POWER, 8000, 0), 1.0f)
+                            .build())));
 
     public static final RegistryObject<Item> BLAZING_OARFISH = ITEMS.register("blazing_oarfish",
-            () -> new SFTooltipItem(new Item.Properties()));
+            () -> new SFTooltipItem(new Item.Properties()
+                    .food(new FoodProperties.Builder()
+                            .nutrition(30)
+                            .saturationMod(40f)
+                            .effect(() -> new MobEffectInstance(MobEffects.FIRE_RESISTANCE, 12000, 0), 1.0f)
+                            .effect(() -> new MobEffectInstance(MobEffects.REGENERATION, 3600, 1), 1.0f)
+                            .build())));
 
     public static final RegistryObject<Item> CRYSTALLINE_SNAKEHEAD = ITEMS.register("crystalline_snakehead",
-            () -> new SFTooltipItem(new Item.Properties()));
+            () -> new SFTooltipItem(new Item.Properties()
+                    .food(new FoodProperties.Builder()
+                            .nutrition(30)
+                            .saturationMod(40f)
+                            .effect(() -> new MobEffectInstance(MobEffects.LUCK, 12000, 1), 1.0f)
+                            .effect(() -> new MobEffectInstance(MobEffects.ABSORPTION, 2400, 2), 1.0f)
+                            .build())));
 
     public static final RegistryObject<Item> DEMON_GAR = ITEMS.register("demon_gar",
-            () -> new SFTooltipItem(new Item.Properties()));
+            () -> new SFTooltipItem(new Item.Properties()
+                    .food(new FoodProperties.Builder()
+                            .nutrition(30)
+                            .saturationMod(40f)
+                            .effect(() -> new MobEffectInstance(MobEffects.DAMAGE_BOOST, 6000, 2), 1.0f)
+                            .effect(() -> new MobEffectInstance(MobEffects.DIG_SPEED, 6000, 3), 1.0f)
+                            .build())));
 
     public static final RegistryObject<CreativeModeTab> TAB = CREATIVE_MODE_TABS.register("items", () -> CreativeModeTab.builder()
             .title(Component.translatable("itemGroup.stardewFishing"))

--- a/src/main/java/com/bonker/stardewfishing/server/data/FishBehaviorReloadListener.java
+++ b/src/main/java/com/bonker/stardewfishing/server/data/FishBehaviorReloadListener.java
@@ -64,13 +64,13 @@ public class FishBehaviorReloadListener extends SimplePreparableReloadListener<M
     protected void apply(Map<String, JsonObject> jsonObjects, ResourceManager pResourceManager, ProfilerFiller pProfiler) {
         for (Map.Entry<String, JsonObject> entry : jsonObjects.entrySet()) {
             FishBehaviorList.CODEC.parse(JsonOps.INSTANCE, entry.getValue())
-                    .resultOrPartial(errorMsg -> StardewFishing.LOGGER.warn(makeError(entry.getKey(), errorMsg)))
+                    .resultOrPartial(errorMsg -> StardewFishing.LOGGER.error(makeError(entry.getKey(), errorMsg)))
                     .ifPresent(behaviorList -> {
                         behaviorList.behaviors.forEach((loc, fishBehavior) -> {
                             Item item = ForgeRegistries.ITEMS.getValue(loc);
                             if (item == Items.AIR) {
                                 if (ModList.get().isLoaded(loc.getNamespace())) {
-                                    throw new RuntimeException(makeError(entry.getKey(), "Mod '" + loc.getNamespace() + "' present but item not registered: " + loc.getPath()));
+                                    StardewFishing.LOGGER.error(makeError(entry.getKey(), "Mod '" + loc.getNamespace() + "' present but item not registered: " + loc.getPath()));
                                 }
                             } else {
                                 if (behaviorList.replace || !fishBehaviors.containsKey(item)) {

--- a/src/main/java/com/bonker/stardewfishing/server/data/MinigameModifiersReloadListener.java
+++ b/src/main/java/com/bonker/stardewfishing/server/data/MinigameModifiersReloadListener.java
@@ -50,12 +50,12 @@ public class MinigameModifiersReloadListener extends SimplePreparableReloadListe
     protected void apply(Map<String, JsonObject> jsonObjects, ResourceManager pResourceManager, ProfilerFiller pProfiler) {
         for (Map.Entry<String, JsonObject> entry : jsonObjects.entrySet()) {
             ModifiersList.CODEC.parse(JsonOps.INSTANCE, entry.getValue())
-                    .resultOrPartial(errorMsg -> StardewFishing.LOGGER.warn("Failed to decode minigame modifiers list {} in data pack {} - {}", LOCATION, entry.getKey(), errorMsg))
+                    .resultOrPartial(errorMsg -> StardewFishing.LOGGER.error(makeError(entry.getKey(), errorMsg)))
                     .ifPresent(behaviorList -> behaviorList.modifiers.forEach((loc, minigameModifiers) -> {
                         Item item = ForgeRegistries.ITEMS.getValue(loc);
                         if (item == Items.AIR) {
                             if (ModList.get().isLoaded(loc.getNamespace())) {
-                                throw new RuntimeException("Mod '" + loc.getNamespace() + "' present but item not registered: " + loc.getPath());
+                                StardewFishing.LOGGER.error(makeError(entry.getKey(), "Mod '" + loc.getNamespace() + "' present but item not registered: " + loc.getPath()));
                             }
                         } else {
                             if (behaviorList.replace || !modifiers.containsKey(item)) {
@@ -66,6 +66,10 @@ public class MinigameModifiersReloadListener extends SimplePreparableReloadListe
                         }
                     }));
         }
+    }
+
+    private static String makeError(String datapackID, String description) {
+        return "Failed to decode minigame modifier list " + LOCATION + " in data pack " + datapackID + " - " + description;
     }
 
     public static MinigameModifiersReloadListener create() {


### PR DESCRIPTION
I was thinking of ways to make the legendary fish feel extra special. They are neat trophies but it dawned on me that it could be cool if they were edible and granted powerful status effects to the player and also a lot of saturation!

With each legendary fish granting status effects that are themed, So you can fish up a legendary fish of your choice and use them in a boss fight or for fire resistance in the nether or something! It makes fishing into an extra activity that can directly contribute towards convenience or progression! It's just a concept and if it goes against the philosophy of the mod no offence will be taken. 

Using this mod in my pack MC Eternal 2 and I love it! 
