### PR TITLE
Fix NeoForge 26.2 screen event compatibility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ minecraft_version=26.2
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[26.2]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=26.2.0.19-beta
+neo_version=26.2.0.64
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 
@@ -28,7 +28,7 @@ mod_name=Stardew Fishing
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=MIT
 # The mod version. See https://semver.org/
-mod_version=3.7
+mod_version=3.7.1
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/com/bonker/stardewfishing/client/ClientEvents.java
+++ b/src/main/java/com/bonker/stardewfishing/client/ClientEvents.java
@@ -5,7 +5,6 @@ import com.bonker.stardewfishing.StardewFishing;
 import com.bonker.stardewfishing.common.init.SFBlockEntities;
 import com.bonker.stardewfishing.common.init.SFParticles;
 import com.bonker.stardewfishing.common.init.SFSoundEvents;
-import com.bonker.stardewfishing.proxy.ClientProxy;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.resources.sounds.SimpleSoundInstance;
@@ -31,9 +30,12 @@ public class ClientEvents {
     }
 
     @SubscribeEvent
-    public static void onScreenRendered(final ContainerScreenEvent.Render.Foreground event) {
-        if (SFConfig.isInventoryEquippingEnabled()) {
-            RodTooltipHandler.render(event.getGuiGraphics(), ClientProxy.getPartialTick(), event.getMouseX() - event.getContainerScreen().getLeftPos(), event.getMouseY() - event.getContainerScreen().getTopPos());
+    public static void onScreenRendered(final ScreenEvent.Render.Foreground event) {
+        if (SFConfig.isInventoryEquippingEnabled()
+                && event.getScreen() instanceof AbstractContainerScreen<?> containerScreen) {
+            RodTooltipHandler.render(event.getGuiGraphics(), event.getPartialTick(),
+                    event.getMouseX() - containerScreen.getLeftPos(),
+                    event.getMouseY() - containerScreen.getTopPos());
         }
     }
 

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -69,7 +69,7 @@ file="META-INF/accesstransformer.cfg"
     # Optional field describing why the dependency is required or why it is incompatible
     # reason="..."
     # The version range of the dependency
-    versionRange="[${neo_version},)" #mandatory
+    versionRange="[26.2.0.40-beta,)" #mandatory
     # An ordering relationship for the dependency.
     # BEFORE - This mod is loaded BEFORE the dependency
     # AFTER - This mod is loaded AFTER the dependency


### PR DESCRIPTION
## Bug

Stardew Fishing 3.7 crashes during mod loading on NeoForge 26.2.0.40-beta and later.

The attached crash screenshot and log show:

![crash screen](https://img.f1a.me/api/images/f97b04be-a564-4db8-901d-c32c0738d00e)

<details>

<summary>Crash logs: </summary>

```log
[20:42:07] [modloading-worker-0/INFO]: NeoForge mod loading, version 26.2.0.40-beta, for MC 26.2
[20:42:07] [modloading-worker-0/ERROR]: Failed to register automatic subscribers. ModID: stardew_fishing
java.lang.NoClassDefFoundError: net/neoforged/neoforge/client/event/ContainerScreenEvent$Render$Foreground
	at java.base/java.lang.Class.getDeclaredMethods0(Native Method)
	at java.base/java.lang.Class.privateGetDeclaredMethods(Class.java:3010)
	at java.base/java.lang.Class.getDeclaredMethods(Class.java:2329)
	at net.neoforged.fml.javafmlmod.AutomaticEventSubscriber.lambda$inject$4(AutomaticEventSubscriber.java:56)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
	at net.neoforged.fml.javafmlmod.AutomaticEventSubscriber.inject(AutomaticEventSubscriber.java:47)
	at net.neoforged.fml.javafmlmod.FMLModContainer.constructMod(FMLModContainer.java:129)
	at net.neoforged.fml.ModLoader.lambda$constructMods$0(ModLoader.java:125)
	at net.neoforged.fml.ModLoader.lambda$dispatchParallelTask$3(ModLoader.java:203)
	at java.base/java.util.concurrent.CompletableFuture.uniHandle(CompletableFuture.java:955)
	at java.base/java.util.concurrent.CompletableFuture$UniHandle.tryFire(CompletableFuture.java:932)
	at java.base/java.util.concurrent.CompletableFuture$Completion.exec(CompletableFuture.java:504)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:511)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1450)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2019)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
Caused by: java.lang.ClassNotFoundException: net.neoforged.neoforge.client.event.ContainerScreenEvent$Render$Foreground
	at net.neoforged.fml.classloading.ModuleClassLoader.loadClass(ModuleClassLoader.java:254)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:490)
	... 16 more
[20:42:07] [main/FATAL]: Failed to wait for future Mod Construction, 1 errors found
[20:42:07] [main/FATAL]: Preparing crash report with UUID b0b00722-e5c0-4de0-b6a1-239dbcb6b281
```

</details>

NeoForge 26.2.0.40-beta removed `ContainerScreenEvent.Render.Foreground` and moved the foreground render event to `ScreenEvent.Render.Foreground`.

## Fix

- Migrated `ClientEvents.onScreenRendered` to `ScreenEvent.Render.Foreground`.
- Added a guard so tooltip rendering only runs for `AbstractContainerScreen` instances.
- Switched to the event-provided partial tick and screen coordinates.
- Updated the NeoForge build version to `26.2.0.64`.
- Set the minimum NeoForge version to `26.2.0.40-beta`.
- Bumped the mod version to `3.7.1`.

## Verification

- `bash gradlew build`
- Tested with NeoForge `26.2.0.40-beta`.
- Tested with NeoForge `26.2.0.64`.
- Functional testing of the mod was successful.
- No crashes or error messages occurred during either test.